### PR TITLE
add `run` and `--home` to cosmovisor ExecStart

### DIFF
--- a/upgrades/v1.2.0/guide.md
+++ b/upgrades/v1.2.0/guide.md
@@ -92,7 +92,7 @@ After=network-online.target
 
 [Service]
 User=$USER
-ExecStart=$GOPATH/bin/cosmovisor start
+ExecStart=$GOPATH/bin/cosmovisor run start --home $HOME/.lumd
 Restart=always
 RestartSec=3
 LimitNOFILE=4096


### PR DESCRIPTION
prevents some edge situations where cosmovisor isn't able to create the upgrade-info.json because it doesn't know where